### PR TITLE
feat: add BloomFilter data structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Perfect for **HFT**, **gaming**, **embedded systems**, and **real-time processin
 | [**RingBuffer**](https://jsrivaya.github.io/loon/data-structures/ring-buffer/) | `loon/ring_buffer.hpp` | Fixed-size circular queue | **3.2x** faster than `std::queue` |
 | [**SpscQueue**](https://jsrivaya.github.io/loon/data-structures/spsc-queue/) | `loon/spsc.hpp` | Lock-free single-producer single-consumer queue | **18.7x** faster than mutex queue |
 | [**LRU Cache**](https://jsrivaya.github.io/loon/data-structures/lru-cache/) | `loon/lru.hpp` | Least Recently Used cache | O(1) get/put |
+| [**BloomFilter**](https://jsrivaya.github.io/loon/data-structures/bloom-filter/) | `loon/bloom_filter.hpp` | Probabilistic membership filter | Configurable false positive rate |
 | [**RedisList**](https://jsrivaya.github.io/loon/data-structures/redis-list/) | `loon/redis_list.hpp` | Redis-style doubly-linked list | O(1) push/pop |
 
 ### Complexity Summary
@@ -135,6 +136,22 @@ auto val = cache.get(1);  // std::optional<std::reference_wrapper<V>>
 if (val) {
     std::cout << val->get();  // "hello"
 }
+```
+
+### [BloomFilter](https://jsrivaya.github.io/loon/data-structures/bloom-filter/)
+
+```cpp
+#include <loon/bloom_filter.hpp>
+
+auto filter = loon::BloomFilter<8192>::with_capacity(1000, 0.01);
+
+filter.insert("session:123");
+if (filter.contains("session:123")) {
+    // key may exist, proceed to expensive lookup
+}
+
+filter.false_positive_rate();  // estimated runtime FPR
+filter.clear();                // reset all bits
 ```
 
 ### [RedisList](https://jsrivaya.github.io/loon/data-structures/redis-list/)

--- a/docs-src/data-structures/bloom-filter.md
+++ b/docs-src/data-structures/bloom-filter.md
@@ -1,0 +1,71 @@
+# Bloom Filter
+
+A fixed-size probabilistic data structure for membership checks with controllable false positive rates.
+
+## Header
+
+```cpp
+#include <loon/bloom_filter.hpp>
+```
+
+## Overview
+
+`loon::BloomFilter` uses a compact bit array and multiple hash probes to provide fast membership checks:
+
+- `contains(key) == false`: key is definitely absent
+- `contains(key) == true`: key is possibly present (false positives are possible)
+
+Bloom filters do not produce false negatives as long as the same hash configuration is used for insertion and lookup.
+
+## Usage
+
+```cpp
+auto filter = loon::BloomFilter<8192>::with_capacity(1000, 0.01);
+
+filter.insert("user:42");
+filter.insert("user:17");
+
+if (filter.contains("user:42")) {
+  // key may exist
+}
+
+auto fpr = filter.false_positive_rate();
+filter.clear();
+```
+
+## API Reference
+
+### Constructors
+
+| Constructor | Description |
+|-------------|-------------|
+| `BloomFilter(size_t hash_functions = 3)` | Creates an empty filter with configurable hash count |
+| `BloomFilter::with_capacity(expected_items, target_fpr)` | Returns a filter tuned for expected load and target FPR |
+
+### Member Functions
+
+| Operation | Return Type | Description |
+|-----------|-------------|-------------|
+| `insert(key)` | `void` | Inserts a key into the filter |
+| `contains(key)` | `bool` | Checks membership (`false` = definitely absent) |
+| `clear()` | `void` | Clears all bits |
+| `false_positive_rate()` | `double` | Returns estimated false positive rate |
+| `hash_functions()` | `size_t` | Returns configured hash function count |
+| `size()` | `size_t` | Returns number of insertions performed |
+| `bit_count()` | `size_t` | Returns compile-time bit count `N` |
+
+## Complexity
+
+| Operation | Time | Space |
+|-----------|------|-------|
+| `insert(key)` | O(k) | O(1) |
+| `contains(key)` | O(k) | O(1) |
+| `clear()` | O(n / word_size) | O(1) |
+
+Where `k` is the number of hash functions and `n` is the number of bits.
+
+## Notes
+
+- Memory usage is fixed at compile time (`N` bits)
+- More bits and fewer insertions improve false positive rate
+- Typical usage: cache pre-checks, routing filters, dedupe hints

--- a/include/loon/bloom_filter.hpp
+++ b/include/loon/bloom_filter.hpp
@@ -1,0 +1,196 @@
+// Copyright (c) 2026 Jorge Suarez-Rivaya
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+/// @file bloom_filter.hpp
+/// @brief Space-efficient probabilistic set membership data structure.
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <string>
+#include <utility>
+
+namespace loon {
+
+namespace detail {
+
+template <typename Key>
+struct BloomSecondaryHash {
+  size_t operator()(const Key& key) const {
+    uint64_t value = static_cast<uint64_t>(std::hash<Key>{}(key));
+    value += 0x9e3779b97f4a7c15ULL;
+    value = (value ^ (value >> 30)) * 0xbf58476d1ce4e5b9ULL;
+    value = (value ^ (value >> 27)) * 0x94d049bb133111ebULL;
+    value ^= (value >> 31);
+    return static_cast<size_t>(value);
+  }
+};
+
+} // namespace detail
+
+/// @brief Fixed-size Bloom filter for fast probabilistic membership checks.
+///
+/// BloomFilter stores membership bits in a compact bit array and supports
+/// O(k) insert/contains operations, where k is the number of hash functions.
+/// It guarantees no false negatives and allows false positives.
+///
+/// @tparam N Number of bits in the filter.
+/// @tparam Key Key type used for insert/contains operations.
+/// @tparam PrimaryHash Primary hash function.
+/// @tparam SecondaryHash Secondary hash function used for double hashing.
+///
+/// @par Example
+/// @code
+/// loon::BloomFilter<4096> filter;
+/// filter.insert("alpha");
+/// bool may_exist = filter.contains("alpha");
+/// @endcode
+template <size_t N, typename Key = std::string, typename PrimaryHash = std::hash<Key>,
+          typename SecondaryHash = detail::BloomSecondaryHash<Key>>
+class BloomFilter {
+  static_assert(N > 0, "BloomFilter bit count must be greater than 0");
+
+ public:
+  /// @brief Construct an empty Bloom filter.
+  /// @param hash_functions Number of hash probes per insert/lookup.
+  /// @param primary_hash Primary hash algorithm instance.
+  /// @param secondary_hash Secondary hash algorithm instance.
+  explicit BloomFilter(size_t hash_functions = 3, PrimaryHash primary_hash = PrimaryHash{},
+                       SecondaryHash secondary_hash = SecondaryHash{})
+      : hash_functions_(std::clamp(hash_functions, size_t{1}, kMaxHashFunctions)),
+        primary_hash_(std::move(primary_hash)),
+        secondary_hash_(std::move(secondary_hash)) {}
+
+  /// @brief Build a Bloom filter tuned for expected load and target FPR.
+  ///
+  /// For fixed-size filters (N bits), this chooses the smallest hash count that
+  /// meets target_fpr for expected_items when possible. If target_fpr cannot be
+  /// met with this N, it falls back to the analytically optimal hash count.
+  ///
+  /// @param expected_items Estimated number of insertions.
+  /// @param target_fpr Desired false positive rate in (0, 1).
+  /// @param primary_hash Primary hash algorithm instance.
+  /// @param secondary_hash Secondary hash algorithm instance.
+  /// @return Tuned BloomFilter instance.
+  static BloomFilter with_capacity(size_t expected_items, double target_fpr,
+                                   PrimaryHash primary_hash = PrimaryHash{},
+                                   SecondaryHash secondary_hash = SecondaryHash{}) {
+    if (expected_items == 0) {
+      return BloomFilter(1, std::move(primary_hash), std::move(secondary_hash));
+    }
+
+    if (!(target_fpr > 0.0 && target_fpr < 1.0)) {
+      target_fpr = 0.01;
+    }
+
+    size_t selected_hash_functions = optimal_hash_functions(expected_items);
+    for (size_t k = 1; k <= kMaxHashFunctions; ++k) {
+      if (estimate_false_positive_rate(expected_items, k) <= target_fpr) {
+        selected_hash_functions = k;
+        break;
+      }
+    }
+
+    return BloomFilter(selected_hash_functions, std::move(primary_hash), std::move(secondary_hash));
+  }
+
+  /// @brief Insert a key into the filter.
+  /// @param key Key to insert.
+  void insert(const Key& key) {
+    const auto [base, step] = hashes_for(key);
+    for (size_t i = 0; i < hash_functions_; ++i) {
+      set_bit(index_for(base, step, i));
+    }
+    ++inserted_items_;
+  }
+
+  /// @brief Check if a key may be present.
+  /// @param key Key to query.
+  /// @return false means definitely absent, true means possibly present.
+  [[nodiscard]] bool contains(const Key& key) const {
+    const auto [base, step] = hashes_for(key);
+    for (size_t i = 0; i < hash_functions_; ++i) {
+      if (!is_set(index_for(base, step, i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// @brief Clear all bits in the filter.
+  void clear() {
+    bits_.fill(0);
+    inserted_items_ = 0;
+  }
+
+  /// @brief Estimated false positive rate based on insertion count.
+  [[nodiscard]] double false_positive_rate() const {
+    return estimate_false_positive_rate(inserted_items_, hash_functions_);
+  }
+
+  /// @brief Return configured number of hash functions.
+  [[nodiscard]] size_t hash_functions() const { return hash_functions_; }
+
+  /// @brief Return number of performed insertions.
+  [[nodiscard]] size_t size() const { return inserted_items_; }
+
+  /// @brief Return number of bits in the filter.
+  [[nodiscard]] size_t bit_count() const { return N; }
+
+ private:
+  static constexpr size_t kWordBits = 64;
+  static constexpr size_t kWordCount = (N + kWordBits - 1) / kWordBits;
+  static constexpr size_t kMaxHashFunctions = 64;
+
+  std::array<uint64_t, kWordCount> bits_{};
+  size_t hash_functions_;
+  size_t inserted_items_ = 0;
+  PrimaryHash primary_hash_;
+  SecondaryHash secondary_hash_;
+
+  static size_t optimal_hash_functions(size_t expected_items) {
+    const auto ratio = static_cast<double>(N) / static_cast<double>(expected_items);
+    const auto estimate = static_cast<size_t>(std::round(ratio * std::log(2.0)));
+    return std::clamp(estimate, size_t{1}, kMaxHashFunctions);
+  }
+
+  static double estimate_false_positive_rate(size_t items, size_t hash_functions) {
+    if (items == 0) {
+      return 0.0;
+    }
+
+    const auto n = static_cast<double>(items);
+    const auto m = static_cast<double>(N);
+    const auto k = static_cast<double>(hash_functions);
+    return std::pow(1.0 - std::exp((-k * n) / m), k);
+  }
+
+  [[nodiscard]] std::pair<size_t, size_t> hashes_for(const Key& key) const {
+    const auto base = static_cast<size_t>(primary_hash_(key));
+    auto step = static_cast<size_t>(secondary_hash_(key));
+    if (step == 0) {
+      step = 0x9e3779b97f4a7c15ULL;
+    }
+    return {base, step};
+  }
+
+  [[nodiscard]] static size_t index_for(size_t base, size_t step, size_t i) {
+    const auto iteration = static_cast<uint64_t>(i);
+    return static_cast<size_t>(
+        (static_cast<uint64_t>(base) + iteration * step + iteration * iteration) % N);
+  }
+
+  void set_bit(size_t index) { bits_[index / kWordBits] |= (uint64_t{1} << (index % kWordBits)); }
+
+  [[nodiscard]] bool is_set(size_t index) const {
+    return (bits_[index / kWordBits] & (uint64_t{1} << (index % kWordBits))) != 0;
+  }
+};
+
+} // namespace loon

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
   - Data Structures:
       - Ring Buffer: data-structures/ring-buffer.md
       - LRU Cache: data-structures/lru-cache.md
+      - Bloom Filter: data-structures/bloom-filter.md
       - Redis List: data-structures/redis-list.md
       - SPSC Queue: data-structures/spsc-queue.md
   - Benchmarks: benchmarks.md

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,7 @@ find_package(GTest REQUIRED)
 include(GoogleTest)
 
 add_executable(loon_tests
+    test_bloom_filter.cpp
     test_lru.cpp
     test_redis_list.cpp
     test_ring_buffer.cpp

--- a/test/test_bloom_filter.cpp
+++ b/test/test_bloom_filter.cpp
@@ -1,0 +1,99 @@
+#include <loon/bloom_filter.hpp>
+
+#include <gtest/gtest.h>
+#include <string>
+
+namespace {
+
+struct LengthHash {
+  size_t operator()(const std::string& value) const {
+    return value.size() * 1469598103934665603ULL;
+  }
+};
+
+struct RollingHash {
+  size_t operator()(const std::string& value) const {
+    size_t hash = 0;
+    for (const auto ch : value) {
+      hash = hash * 131 + static_cast<unsigned char>(ch);
+    }
+    return hash;
+  }
+};
+
+} // namespace
+
+class BloomFilterTest : public ::testing::Test {
+ protected:
+  loon::BloomFilter<4096> filter;
+};
+
+TEST_F(BloomFilterTest, EmptyFilterContainsNothing) {
+  EXPECT_FALSE(filter.contains("alpha"));
+}
+
+TEST_F(BloomFilterTest, InsertAndContains) {
+  filter.insert("alpha");
+  filter.insert("beta");
+  filter.insert("gamma");
+
+  EXPECT_TRUE(filter.contains("alpha"));
+  EXPECT_TRUE(filter.contains("beta"));
+  EXPECT_TRUE(filter.contains("gamma"));
+}
+
+TEST_F(BloomFilterTest, ClearResetsFilter) {
+  filter.insert("alpha");
+  ASSERT_TRUE(filter.contains("alpha"));
+  ASSERT_GT(filter.false_positive_rate(), 0.0);
+
+  filter.clear();
+
+  EXPECT_FALSE(filter.contains("alpha"));
+  EXPECT_EQ(filter.size(), 0);
+  EXPECT_DOUBLE_EQ(filter.false_positive_rate(), 0.0);
+}
+
+TEST_F(BloomFilterTest, HashFunctionCountIsConfigurable) {
+  loon::BloomFilter<4096> tuned_filter(7);
+
+  EXPECT_EQ(tuned_filter.hash_functions(), 7);
+  tuned_filter.insert("value");
+  EXPECT_TRUE(tuned_filter.contains("value"));
+}
+
+TEST_F(BloomFilterTest, FalsePositiveRateTracksInsertions) {
+  EXPECT_DOUBLE_EQ(filter.false_positive_rate(), 0.0);
+
+  filter.insert("alpha");
+  const auto after_first_insert = filter.false_positive_rate();
+  filter.insert("beta");
+  const auto after_second_insert = filter.false_positive_rate();
+
+  EXPECT_GT(after_first_insert, 0.0);
+  EXPECT_GT(after_second_insert, after_first_insert);
+}
+
+TEST_F(BloomFilterTest, WithCapacityChoosesTargetRate) {
+  constexpr size_t expected_items = 200;
+  constexpr double target_fpr = 0.01;
+  auto tuned_filter = loon::BloomFilter<8192>::with_capacity(expected_items, target_fpr);
+
+  EXPECT_GE(tuned_filter.hash_functions(), 1);
+
+  for (size_t i = 0; i < expected_items; ++i) {
+    tuned_filter.insert("item-" + std::to_string(i));
+  }
+
+  EXPECT_LE(tuned_filter.false_positive_rate(), target_fpr + 1e-12);
+}
+
+TEST_F(BloomFilterTest, SupportsCustomHashAlgorithms) {
+  loon::BloomFilter<2048, std::string, LengthHash, RollingHash> custom_filter(4);
+
+  custom_filter.insert("loon");
+  custom_filter.insert("bloom");
+
+  EXPECT_TRUE(custom_filter.contains("loon"));
+  EXPECT_TRUE(custom_filter.contains("bloom"));
+}


### PR DESCRIPTION
## Description

This PR implements issue #7 by adding a BloomFilter data structure for space-efficient probabilistic membership checks.

### Changes included

- Added BloomFilter with configurable number of hash functions.
- Added support for custom primary and secondary hash algorithms.
- Added `with_capacity(expected_items, target_fpr)` factory for parameter tuning.
- Added `insert`, `contains`, `clear`, `false_positive_rate`, `hash_functions`, `size`, and `bit_count` APIs.
- Added BloomFilter unit tests and wired them into the existing CMake test target.
- Updated documentation navigation and user-facing docs.
- Added a dedicated Bloom Filter documentation page.

### Validation performed

```bash
cmake -S . -B build -DLOON_BUILD_TESTS=ON
cmake --build build
ctest --test-dir build --output-on-failure
```

### Result

- 42 tests passed, 0 failed.

## Related Issue

Closes #7

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run `make check-format` and fixed any issues
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make build`)
- [x] I have updated documentation if needed
- [x] My changes generate no new warnings

## Performance Impact

N/A (no dedicated benchmark or performance regression measurements were added in this PR).

## Additional Notes

- Bloom filters guarantee no false negatives and allow false positives by design.
- The false positive rate is estimated from inserted item count, bit size, and hash function count.
- Existing warnings observed during build are in `test/test_ring_buffer.cpp` and were not introduced by this PR.
- The estimation follows the standard approximation:

$$
FPR \approx (1 - e^{-kn/m})^k
$$

where:
- $n$ is inserted item count,
- $m$ is bit count,
- $k$ is hash function count.
